### PR TITLE
Android foreground service

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="67"
+    android:versionName="2.8.0"
+    package="io.fyne.demo">
+
+    <application
+        android:label="Fyne Demo"
+        android:debuggable="true">
+
+        <activity
+            android:name="org.golang.app.GoNativeActivity"
+            android:exported="true"
+            android:configChanges="0x2a0"
+            android:label="Fyne Demo">
+
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="Fyne_Demo" />
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name="org.golang.app.FyneNotificationReceiver"
+            android:exported="false" />
+
+        <service
+            android:name="org.golang.app.GoForegroundService"
+            android:foregroundServiceType="specialUse" />
+    </application>
+
+    <uses-permission
+            android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
+    <uses-permission
+            android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
+    <uses-permission
+            android:name="android.permission.INTERNET" />
+
+    <uses-permission
+            android:name="android.permission.FOREGROUND_SERVICE" />
+</manifest>

--- a/go.mod
+++ b/go.mod
@@ -9,14 +9,13 @@ require (
 )
 
 require (
-	fyne.io/systray v1.12.2 // indirect
+	fyne.io/systray v1.12.3-0.20260810170012-af4e8e793ec4 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/FyshOS/fancyfs v0.0.1 // indirect
 	github.com/anthonynsimon/bild v0.14.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.4 // indirect
-	github.com/fredbi/uri v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fyne-io/gl-js v0.2.1-0.20260315212741-029c47fd27e8 // indirect
 	github.com/fyne-io/glfw-js v0.4.0 // indirect
@@ -45,3 +44,5 @@ require (
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace fyne.io/fyne/v2 => github.com/LeoHalb/fyne/v2 v2.7.4-0.20260820180157-048008f06575

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-fyne.io/fyne/v2 v2.8.0 h1:KNUdIk1eKsXSPy/wU6MdiR1hppAPvyzbjPbtJ8h6EUQ=
-fyne.io/fyne/v2 v2.8.0/go.mod h1:tLJK7CVtUBOnMiSDR+J88t/quiGuEhwGs09tIVM1RXg=
-fyne.io/systray v1.12.2 h1:Y8DZxgLHsVQt6rY9Zrkkg+j67S7vv/1F2viOWKPpVeA=
-fyne.io/systray v1.12.2/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
+fyne.io/systray v1.12.3-0.20260810170012-af4e8e793ec4 h1:149/+Wa5EsLLXfyj2pdTmvnQf2VIlgCIwSjcCTHYhIo=
+fyne.io/systray v1.12.3-0.20260810170012-af4e8e793ec4/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/FyshOS/fancyfs v0.0.1 h1:kgvm7VvwOMLkYTqSflplp62SlMVWQ2uAoHw9CXwXHYg=
 github.com/FyshOS/fancyfs v0.0.1/go.mod h1:S5SHVz/5R72iCXOxCqdcyTPSlg3JxNd0gaHyGBSrY8A=
+github.com/LeoHalb/fyne/v2 v2.7.4-0.20260820180157-048008f06575 h1:WZ4UkeWieFV71XR7mrid+y1VaZBw/hLS8VpHGU7F0hA=
+github.com/LeoHalb/fyne/v2 v2.7.4-0.20260820180157-048008f06575/go.mod h1:kpeuFrClm0fiAgJYr2soTfwKMT5rzNcSKzmgGjxvHOY=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.15.0 h1:LxXTQHFoYrstG2nnV9y2X5O94sOBzf0CIUpSTbpxvMc=
@@ -20,10 +20,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yAo=
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felixge/fgprof v0.9.3 h1:VvyZxILNuCiUCSXtPtYmmtGvb65nqXh2QFWc0Wpf2/g=
-github.com/felixge/fgprof v0.9.3/go.mod h1:RdbpDgzqYVh/T9fPELJyV7EYJuHB55UTEULNun8eiPw=
-github.com/fredbi/uri v1.1.1 h1:xZHJC08GZNIUhbP5ImTHnt5Ya0T8FI2VAwI/37kh2Ko=
-github.com/fredbi/uri v1.1.1/go.mod h1:4+DZQ5zBjEwQCDmXW5JdIjz0PUA+yJbvtBv+u+adr5o=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fyne-io/gl-js v0.2.1-0.20260315212741-029c47fd27e8 h1:0kdPD/GEntpWmZEK5Zu/xE6Tr37jYCVDf9QP8lA/QK8=
@@ -46,8 +42,6 @@ github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3 h1:drBZz
 github.com/go-text/typesetting-utils v0.0.0-20260223113751-2d88ac90dae3/go.mod h1:3/62I4La/HBRX9TcTpBj4eipLiwzf+vhI+7whTc9V7o=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
-github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8fqdZK1R22vvA0J7JZKcuOIQ7Y=
-github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/hack-pad/go-indexeddb v0.3.2 h1:DTqeJJYc1usa45Q5r52t01KhvlSN02+Oq+tQbSBI91A=
 github.com/hack-pad/go-indexeddb v0.3.2/go.mod h1:QvfTevpDVlkfomY498LhstjwbPW6QC4VC/lxYb0Kom0=
 github.com/hack-pad/safejs v0.1.0 h1:qPS6vjreAqh2amUqj4WNG1zIw7qlRQJ9K10eDKMCnE8=
@@ -68,8 +62,6 @@ github.com/nicksnyder/go-i18n/v2 v2.5.1 h1:IxtPxYsR9Gp60cGXjfuR/llTqV8aYMsC472zD
 github.com/nicksnyder/go-i18n/v2 v2.5.1/go.mod h1:DrhgsSDZxoAfvVrBVLXoxZn/pN5TXqaDbq7ju94viiQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
-github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rymdport/portal v0.4.2 h1:7jKRSemwlTyVHHrTGgQg7gmNPJs88xkbKcIL3NlcmSU=

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"net/url"
-
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/cmd/fyne_settings/settings"
@@ -13,6 +10,8 @@ import (
 	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	"log"
+	"net/url"
 
 	"fyne.io/demo/data"
 	"fyne.io/demo/tutorials"

--- a/tutorials/data.go
+++ b/tutorials/data.go
@@ -4,6 +4,7 @@ package tutorials
 
 import (
 	"image/color"
+	"runtime"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/styles"
@@ -15,6 +16,18 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 )
+
+func init() {
+	if runtime.GOOS == "android" {
+		Tutorials["foregroundService"] = Tutorial{
+			"Foreground Service",
+			"Demonstrates the use of a foreground service on Android.",
+			foregroundServiceScreen,
+		}
+
+		TutorialIndex[""] = append(TutorialIndex[""], "foregroundService")
+	}
+}
 
 // OnChangeFuncs is a slice of functions that can be registered
 // to run when the user switches tutorial.

--- a/tutorials/foregroundService_android.go
+++ b/tutorials/foregroundService_android.go
@@ -1,0 +1,104 @@
+//go:build android
+
+package tutorials
+
+import (
+	"log"
+	"time"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+)
+
+var timestamp time.Time
+var stoppedTime time.Duration
+
+func foregroundServiceScreen(_ fyne.Window) fyne.CanvasObject {
+	label := widget.NewLabel("0s")
+	currentlyRunning := isRunning()
+
+	ticker := time.NewTicker(time.Second)
+	go func() {
+		for {
+			if currentlyRunning {
+				elapsedTime := getElapsed()
+				log.Println("elapsed: ", elapsedTime)
+				fyne.Do(func() {
+					label.SetText(elapsedTime)
+				})
+
+				// Repeated starts update the existing service notification;
+				// the object churn stays on the Java side where the GC owns
+				// it, so this is safe to call once a second.
+				fyne.CurrentApp().StartForegroundService("Demo Clock", elapsedTime)
+			}
+			<-ticker.C
+		}
+	}()
+
+	button := widget.NewButton("Start", nil)
+	button.OnTapped = func() {
+		fyne.CurrentApp().RequestNotificationPermission()
+
+		if !currentlyRunning {
+			fyne.CurrentApp().StartForegroundService("Demo Clock", "0s")
+
+			ticker.Reset(time.Second)
+			start(time.Now().Unix())
+
+			fyne.Do(func() {
+				label.SetText("0s")
+				button.Text = "Stop"
+				button.Refresh()
+			})
+		} else {
+			fyne.CurrentApp().StopForegroundService()
+
+			ticker.Stop()
+			elapsedTime := stop()
+
+			fyne.Do(func() {
+				label.SetText(elapsedTime)
+				button.Text = "Start"
+				button.Refresh()
+			})
+		}
+
+		currentlyRunning = !currentlyRunning
+	}
+
+	c := container.NewVBox(label, button)
+	return c
+}
+
+func start(unixTimestamp int64) {
+	timestamp = time.Unix(unixTimestamp, 0)
+	stoppedTime = 0
+}
+
+func stop() string {
+	if timestamp.IsZero() {
+		stoppedTime = 0
+		return "0s"
+	}
+	stoppedTime = time.Since(timestamp)
+	timestamp = time.Time{}
+	return stoppedTime.Truncate(time.Second).String()
+}
+
+func isRunning() bool {
+	return !timestamp.IsZero()
+}
+
+func getElapsed() string {
+	if timestamp.IsZero() {
+		if stoppedTime != 0 {
+			return stoppedTime.Truncate(time.Second).String()
+		}
+
+		return "0s"
+	}
+
+	return time.Since(timestamp).Truncate(time.Second).String()
+}

--- a/tutorials/foregroundService_other.go
+++ b/tutorials/foregroundService_other.go
@@ -1,0 +1,9 @@
+//go:build !android
+
+package tutorials
+
+import "fyne.io/fyne/v2"
+
+func foregroundServiceScreen(_ fyne.Window) fyne.CanvasObject {
+	return nil
+}


### PR DESCRIPTION
### Adds Android foreground service

On modern Android devices, it's important that you use the `AndroidManifest.xml` from this PR when building with `fyne package`.

When creating one yourself, you need the `<service [...]>` tag and the
`<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />` one